### PR TITLE
Relax oauth2 version

### DIFF
--- a/unsplash.gemspec
+++ b/unsplash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_dependency "httparty", "~> 0.13.5"
-  spec.add_dependency "oauth2",   "~> 1.0.0"
+  spec.add_dependency "oauth2",   "~> 1"
 
   # spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake",    "~> 10.0"


### PR DESCRIPTION
There is a new version of `oauth2` (1.1.0) that support rack 2 which is required by Rails 5.

See discussion here: https://github.com/intridea/oauth2/issues/235

I've simply relaxed the `oauth2` version.

Thanks.